### PR TITLE
Add permit seed scripts for Gold, Gold Plus, and Blue permits

### DIFF
--- a/data/scripts/README.md
+++ b/data/scripts/README.md
@@ -1,0 +1,28 @@
+# Data Scripts
+
+One-off scripts for seeding the `permit_types` and `lot_permit_access` tables.
+
+## Usage
+
+Run from `backend/`:
+
+```bash
+python -m data.scripts.seed_gold_permit
+python -m data.scripts.seed_gold_plus_permit
+python -m data.scripts.seed_blue_permit
+```
+
+Add `--dry-run` to preview without committing.
+
+## Scripts
+
+| Script | Permit | 24/7 Lots | Restricted Lots (6 PM Mon-Fri, all day Sat-Sun) |
+|--------|--------|-----------|--------------------------------------------------|
+| `seed_gold_permit.py` | Gold Permit | 26, 30, 32, 50 | 6, 24 |
+| `seed_gold_plus_permit.py` | Gold Plus Permit | 26, 30, 32, 50, Big Springs 2 | 6, 24 |
+| `seed_blue_permit.py` | Blue Permit | 6, 24, 26, 30, 32, 50 | — |
+
+## Notes
+
+- Scripts skip lots not found in `parking_lots` (only lots returned by the UCR API are seeded).
+- Scripts are idempotent for the permit row (won't duplicate if re-run), but will fail on duplicate `lot_permit_access` entries due to the unique constraint.

--- a/data/scripts/seed_blue_permit.py
+++ b/data/scripts/seed_blue_permit.py
@@ -1,0 +1,76 @@
+"""Seed the Blue Permit and its lot_permit_access rules.
+
+Usage:
+    cd backend && python -m seed_blue_permit
+    cd backend && python -m seed_blue_permit --dry-run
+"""
+
+import argparse
+import asyncio
+
+from sqlalchemy import select
+
+from backend.app.database import async_session_maker
+from backend.app.models import LotPermitAccess, ParkingLot, PermitType
+
+# All Blue Permit lots — 24/7 access
+LOTS_24_7 = ["Lot 6", "Lot 24", "Lot 26", "Lot 30", "Lot 32", "Lot 50"]
+
+
+async def seed(dry_run: bool = False):
+    async with async_session_maker() as session:
+        result = await session.execute(
+            select(PermitType).where(PermitType.name == "Blue Permit")
+        )
+        permit = result.scalar_one_or_none()
+
+        if permit is None:
+            permit = PermitType(
+                name="Blue Permit",
+                description=(
+                    "Valid 24/7 in Lots 6, 24, 26, 30, 32, 50."
+                ),
+            )
+            session.add(permit)
+            await session.flush()
+            print(f"Created permit: {permit.name} ({permit.id})")
+        else:
+            print(f"Permit already exists: {permit.name} ({permit.id})")
+
+        result = await session.execute(
+            select(ParkingLot).where(ParkingLot.name.in_(LOTS_24_7))
+        )
+        lots_by_name = {lot.name: lot for lot in result.scalars().all()}
+
+        missing = set(LOTS_24_7) - set(lots_by_name)
+        if missing:
+            print(f"Skipping lots not in database: {', '.join(sorted(missing))}")
+
+        for name in LOTS_24_7:
+            lot = lots_by_name.get(name)
+            if lot is None:
+                continue
+            session.add(
+                LotPermitAccess(
+                    lot_id=lot.id,
+                    permit_id=permit.id,
+                    days_of_week=None,
+                    access_start=None,
+                    access_end=None,
+                )
+            )
+            print(f"  {name}: 24/7")
+
+        if dry_run:
+            await session.rollback()
+            print("Dry run — no changes committed.")
+        else:
+            await session.commit()
+            print("Done.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    asyncio.run(seed(dry_run=args.dry_run))

--- a/data/scripts/seed_gold_permit.py
+++ b/data/scripts/seed_gold_permit.py
@@ -1,0 +1,113 @@
+"""Seed the Gold Permit and its lot_permit_access rules.
+
+Usage:
+    cd backend && python -m seed_gold_permit
+    cd backend && python -m seed_gold_permit --dry-run
+"""
+
+import argparse
+import asyncio
+from datetime import time
+
+from sqlalchemy import select
+
+from backend.app.database import async_session_maker
+from backend.app.models import LotPermitAccess, ParkingLot, PermitType
+
+# Gold Lots — 24/7 access
+GOLD_LOTS_24_7 = ["Lot 26", "Lot 30", "Lot 32", "Lot 50"]
+
+# Blue Lots — after 6 PM Mon-Fri, all day Sat-Sun
+BLUE_LOTS_RESTRICTED = ["Lot 6", "Lot 24"]
+
+
+async def seed(dry_run: bool = False):
+    async with async_session_maker() as session:
+        result = await session.execute(
+            select(PermitType).where(PermitType.name == "Gold Permit")
+        )
+        permit = result.scalar_one_or_none()
+
+        if permit is None:
+            permit = PermitType(
+                name="Gold Permit",
+                description=(
+                    "Valid 24/7 in Gold Lots (26, 30, 32, 50). "
+                    "Valid in select Blue Lots (6, 24) after 6 PM Mon-Fri "
+                    "and all day Sat-Sun."
+                ),
+            )
+            session.add(permit)
+            await session.flush()
+            print(f"Created permit: {permit.name} ({permit.id})")
+        else:
+            print(f"Permit already exists: {permit.name} ({permit.id})")
+
+        all_lot_names = GOLD_LOTS_24_7 + BLUE_LOTS_RESTRICTED
+        result = await session.execute(
+            select(ParkingLot).where(ParkingLot.name.in_(all_lot_names))
+        )
+        lots_by_name = {lot.name: lot for lot in result.scalars().all()}
+
+        missing = set(all_lot_names) - set(lots_by_name)
+        if missing:
+            print(f"Skipping lots not in database: {', '.join(sorted(missing))}")
+
+        for name in GOLD_LOTS_24_7:
+            lot = lots_by_name.get(name)
+            if lot is None:
+                continue
+            session.add(
+                LotPermitAccess(
+                    lot_id=lot.id,
+                    permit_id=permit.id,
+                    days_of_week=None,
+                    access_start=None,
+                    access_end=None,
+                )
+            )
+            print(f"  {name}: 24/7")
+
+        for name in BLUE_LOTS_RESTRICTED:
+            lot = lots_by_name.get(name)
+            if lot is None:
+                continue
+            session.add(
+                LotPermitAccess(
+                    lot_id=lot.id,
+                    permit_id=permit.id,
+                    days_of_week=[0, 1, 2, 3, 4],
+                    access_start=time(18, 0),
+                    access_end=time(23, 59),
+                )
+            )
+            print(f"  {name}: Mon-Fri 6 PM - 11:59 PM")
+
+        for name in BLUE_LOTS_RESTRICTED:
+            lot = lots_by_name.get(name)
+            if lot is None:
+                continue
+            session.add(
+                LotPermitAccess(
+                    lot_id=lot.id,
+                    permit_id=permit.id,
+                    days_of_week=[5, 6],
+                    access_start=None,
+                    access_end=None,
+                )
+            )
+            print(f"  {name}: Sat-Sun all day")
+
+        if dry_run:
+            await session.rollback()
+            print("Dry run — no changes committed.")
+        else:
+            await session.commit()
+            print("Done.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    asyncio.run(seed(dry_run=args.dry_run))

--- a/data/scripts/seed_gold_plus_permit.py
+++ b/data/scripts/seed_gold_plus_permit.py
@@ -1,0 +1,113 @@
+"""Seed the Gold Plus Permit and its lot_permit_access rules.
+
+Usage:
+    cd backend && python -m seed_gold_plus_permit
+    cd backend && python -m seed_gold_plus_permit --dry-run
+"""
+
+import argparse
+import asyncio
+from datetime import time
+
+from sqlalchemy import select
+
+from backend.app.database import async_session_maker
+from backend.app.models import LotPermitAccess, ParkingLot, PermitType
+
+# Gold Lots + Big Springs 2 — 24/7 access
+LOTS_24_7 = ["Lot 26", "Lot 30", "Lot 32", "Lot 50", "Big Springs 2"]
+
+# Blue Lots — after 6 PM Mon-Fri, all day Sat-Sun
+BLUE_LOTS_RESTRICTED = ["Lot 6", "Lot 24"]
+
+
+async def seed(dry_run: bool = False):
+    async with async_session_maker() as session:
+        result = await session.execute(
+            select(PermitType).where(PermitType.name == "Gold Plus Permit")
+        )
+        permit = result.scalar_one_or_none()
+
+        if permit is None:
+            permit = PermitType(
+                name="Gold Plus Permit",
+                description=(
+                    "Valid 24/7 in Gold Lots (26, 30, 32, 50) and Big Springs 2. "
+                    "Valid in select Blue Lots (6, 24) after 6 PM Mon-Fri "
+                    "and all day Sat-Sun."
+                ),
+            )
+            session.add(permit)
+            await session.flush()
+            print(f"Created permit: {permit.name} ({permit.id})")
+        else:
+            print(f"Permit already exists: {permit.name} ({permit.id})")
+
+        all_lot_names = LOTS_24_7 + BLUE_LOTS_RESTRICTED
+        result = await session.execute(
+            select(ParkingLot).where(ParkingLot.name.in_(all_lot_names))
+        )
+        lots_by_name = {lot.name: lot for lot in result.scalars().all()}
+
+        missing = set(all_lot_names) - set(lots_by_name)
+        if missing:
+            print(f"Skipping lots not in database: {', '.join(sorted(missing))}")
+
+        for name in LOTS_24_7:
+            lot = lots_by_name.get(name)
+            if lot is None:
+                continue
+            session.add(
+                LotPermitAccess(
+                    lot_id=lot.id,
+                    permit_id=permit.id,
+                    days_of_week=None,
+                    access_start=None,
+                    access_end=None,
+                )
+            )
+            print(f"  {name}: 24/7")
+
+        for name in BLUE_LOTS_RESTRICTED:
+            lot = lots_by_name.get(name)
+            if lot is None:
+                continue
+            session.add(
+                LotPermitAccess(
+                    lot_id=lot.id,
+                    permit_id=permit.id,
+                    days_of_week=[0, 1, 2, 3, 4],
+                    access_start=time(18, 0),
+                    access_end=time(23, 59),
+                )
+            )
+            print(f"  {name}: Mon-Fri 6 PM - 11:59 PM")
+
+        for name in BLUE_LOTS_RESTRICTED:
+            lot = lots_by_name.get(name)
+            if lot is None:
+                continue
+            session.add(
+                LotPermitAccess(
+                    lot_id=lot.id,
+                    permit_id=permit.id,
+                    days_of_week=[5, 6],
+                    access_start=None,
+                    access_end=None,
+                )
+            )
+            print(f"  {name}: Sat-Sun all day")
+
+        if dry_run:
+            await session.rollback()
+            print("Dry run — no changes committed.")
+        else:
+            await session.commit()
+            print("Done.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    asyncio.run(seed(dry_run=args.dry_run))


### PR DESCRIPTION
Summary
                                                                                                                       
- Add seed scripts to populate permit_types and lot_permit_access tables for Gold, Gold Plus, and Blue permits with UCR-specific parking rules
- Scripts only seed lots present in the UCR API (Lot 6, 24, 26, 30, 32, 50, Big Springs 2) and skip lots not in the database
- Each script supports a --dry-run flag to preview changes without committing
- Add README documenting script usage and permit access rules